### PR TITLE
omit update check during startup to address #9

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # execute flutter with arguments
-flutter $1 $2 $3 $4 $5 $6
+flutter --no-version-check $1 $2 $3 $4 $5 $6
 
 /bin/bash /usr/local/bin/chown.sh
 


### PR DESCRIPTION
this addresses issue #9.

So i tested the change against dev/beta/stable and checked the timing against upstream/stable

the call is always `time docker run ... --version`

upstream/stable (without change):
```
  ╔════════════════════════════════════════════════════════════════════════════╗
  ║ A new version of Flutter is available!                                     ║
  ║                                                                            ║
  ║ To update to the latest version, run "flutter upgrade".                    ║
  ╚════════════════════════════════════════════════════════════════════════════╝


Flutter 1.22.4 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 1aafb3a8b9 (7 weeks ago) • 2020-11-13 09:59:28 -0800
Engine • revision 2c956a31c0
Tools • Dart 2.10.4

real	0m5.902s
user	0m0.072s
sys	0m0.063s
```

and with the change against self-built images
stable:
```
Flutter 1.22.4 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 1aafb3a8b9 (7 weeks ago) • 2020-11-13 09:59:28 -0800
Engine • revision 2c956a31c0
Tools • Dart 2.10.4

real	0m1.696s
user	0m0.082s
sys	0m0.043s
```

beta:
```
Flutter 1.24.0-10.2.pre • channel beta • https://github.com/flutter/flutter.git
Framework • revision 022b333a08 (7 weeks ago) • 2020-11-18 11:35:09 -0800
Engine • revision 07c1eed46b
Tools • Dart 2.12.0 (build 2.12.0-29.10.beta)

real	0m1.699s
user	0m0.080s
sys	0m0.047s
```

dev:
```
Flutter 1.24.0-10.2.pre • channel dev • https://github.com/flutter/flutter.git
Framework • revision 022b333a08 (7 weeks ago) • 2020-11-18 11:35:09 -0800
Engine • revision 07c1eed46b
Tools • Dart 2.12.0 (build 2.12.0-29.10.beta)

real	0m1.762s
user	0m0.078s
sys	0m0.084s
```