### PR TITLE
Enable hardware keyboard in Android Emulator

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -57,6 +57,7 @@ RUN curl -o flutter.tar.xz $FLUTTER_URL \
   && yes "y" | flutter doctor --android-licenses \
   && flutter doctor \
   && flutter emulators --create \
+  && echo "hw.keyboard = yes" >> /home/$USER/.android/avd/flutter_emulator.avd/config.ini \
   && flutter update-packages
 
 COPY entrypoint.sh /usr/local/bin/

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -57,6 +57,7 @@ RUN curl -o flutter.tar.xz $FLUTTER_URL \
   && yes "y" | flutter doctor --android-licenses \
   && flutter doctor \
   && flutter emulators --create \
+  && echo "hw.keyboard = yes" >> /home/$USER/.android/avd/flutter_emulator.avd/config.ini \
   && flutter update-packages
 
 COPY entrypoint.sh /usr/local/bin/

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -57,6 +57,7 @@ RUN curl -o flutter.tar.xz $FLUTTER_URL \
   && yes "y" | flutter doctor --android-licenses \
   && flutter doctor \
   && flutter emulators --create \
+  && echo "hw.keyboard = yes" >> /home/$USER/.android/avd/flutter_emulator.avd/config.ini \
   && flutter update-packages
 
 COPY entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
I believe hardware keyboard support is a sensible default setting for an emulator running on a PC.